### PR TITLE
feat: Filter device logs using last_sync_of_checkin from ERPNext Shift Type before upload

### DIFF
--- a/essl_erpnext_sync.py
+++ b/essl_erpnext_sync.py
@@ -7,25 +7,30 @@ import sys
 import time
 import logging
 from logging.handlers import RotatingFileHandler
-import shelve  # Using shelve for status persistence
+import pickledb
+from zk import ZK, const
 
 EMPLOYEE_NOT_FOUND_ERROR_MESSAGE = "No Employee found for the given employee field value"
 EMPLOYEE_INACTIVE_ERROR_MESSAGE = "Transactions cannot be created for an Inactive Employee"
 DUPLICATE_EMPLOYEE_CHECKIN_ERROR_MESSAGE = "This employee already has a log with the same timestamp"
 allowlisted_errors = [EMPLOYEE_NOT_FOUND_ERROR_MESSAGE, EMPLOYEE_INACTIVE_ERROR_MESSAGE, DUPLICATE_EMPLOYEE_CHECKIN_ERROR_MESSAGE]
 
-if hasattr(config, 'allowed_exceptions'):
+if hasattr(config,'allowed_exceptions'):
     allowlisted_errors_temp = []
     for error_number in config.allowed_exceptions:
-        allowlisted_errors_temp.append(allowlisted_errors[error_number - 1])
+        allowlisted_errors_temp.append(allowlisted_errors[error_number-1])
     allowlisted_errors = allowlisted_errors_temp
 
-device_punch_values_IN = getattr(config, 'device_punch_values_IN', [0, 4])
-device_punch_values_OUT = getattr(config, 'device_punch_values_OUT', [1, 5])
+device_punch_values_IN = getattr(config, 'device_punch_values_IN', [0,4])
+device_punch_values_OUT = getattr(config, 'device_punch_values_OUT', [1,5])
 ERPNEXT_VERSION = getattr(config, 'ERPNEXT_VERSION', 14)
 
+# possible area of further developemt
+    # Real-time events - setup getting events pushed from the machine rather then polling.
+        #- this is documented as 'Real-time events' in the ZKProtocol manual.
+
 # Notes:
-# Status Keys in status file (shelve)
+# Status Keys in status.json
 #  - lift_off_timestamp
 #  - mission_accomplished_timestamp
 #  - <device_id>_pull_timestamp
@@ -34,58 +39,88 @@ ERPNEXT_VERSION = getattr(config, 'ERPNEXT_VERSION', 14)
 
 def main():
     """Takes care of checking if it is time to pull data based on config,
-    then calling the relevant functions to pull data and push to ERPNext."""
-    
-    status_file = os.path.join(config.LOGS_DIRECTORY, 'status')  # Removed .json extension for shelve
-    with shelve.open(status_file) as status:
-        try:
-            last_lift_off_timestamp = _safe_convert_date(status.get('lift_off_timestamp'), "%Y-%m-%d %H:%M:%S.%f")
-            if (last_lift_off_timestamp and last_lift_off_timestamp < datetime.datetime.now() - datetime.timedelta(minutes=config.PULL_FREQUENCY)) or not last_lift_off_timestamp:
-                status['lift_off_timestamp'] = str(datetime.datetime.now())
-                info_logger.info("Cleared for lift off!")
-                
-                for device in config.devices:
-                    device_attendance_logs = None
-                    info_logger.info("Processing Device: " + device['device_id'])
-                    dump_file = get_dump_file_name_and_directory(device['device_id'], device['ip'])
-                    
+    then calling the relevent functions to pull data and push to EPRNext.
+
+    """
+    try:
+        last_lift_off_timestamp = _safe_convert_date(status.get('lift_off_timestamp'), "%Y-%m-%d %H:%M:%S.%f")
+        if (last_lift_off_timestamp and last_lift_off_timestamp < datetime.datetime.now() - datetime.timedelta(minutes=config.PULL_FREQUENCY)) or not last_lift_off_timestamp:
+            status.set('lift_off_timestamp', str(datetime.datetime.now()))
+            info_logger.info("Cleared for lift off!")
+            for device in config.devices:
+                device_attendance_logs = None
+                info_logger.info("Processing Device: "+ device['device_id'])
+                dump_file = get_dump_file_name_and_directory(device['device_id'], device['ip'])
+                if os.path.exists(dump_file):
+                    info_logger.error('Device Attendance Dump Found in Log Directory. This can mean the program crashed unexpectedly. Retrying with dumped data.')
+                    with open(dump_file, 'r') as f:
+                        file_contents = f.read()
+                        if file_contents:
+                            device_attendance_logs = list(map(lambda x: _apply_function_to_key(x, 'timestamp', datetime.datetime.fromtimestamp), json.loads(file_contents)))
+                try:
+                    # Get the shift type for this device
+                    shift_type_name = None
+                    if hasattr(config, 'shift_type_device_mapping'):
+                        for mapping in config.shift_type_device_mapping:
+                            if device['device_id'] in mapping['related_device_id']:
+                                # If shift_type_name is a list, take the first one (or handle as needed)
+                                shift_type_name = mapping['shift_type_name']
+                                if isinstance(shift_type_name, list):
+                                    shift_type_name = shift_type_name[0]
+                                break
+
+                    if shift_type_name:
+                        last_sync_of_checkin = get_last_sync_of_checkin(shift_type_name)
+                        if last_sync_of_checkin and device_attendance_logs:
+                            # Ensure all timestamps are datetime objects
+                            for log in device_attendance_logs:
+                                if isinstance(log['timestamp'], str):
+                                    log['timestamp'] = datetime.datetime.fromisoformat(log['timestamp'])
+                            device_attendance_logs = [
+                                log for log in device_attendance_logs
+                                if log['timestamp'] > last_sync_of_checkin
+                            ]
+
+                    pull_process_and_push_data(device, device_attendance_logs)
+                    status.set(f'{device["device_id"]}_push_timestamp', str(datetime.datetime.now()))
                     if os.path.exists(dump_file):
-                        info_logger.error('Device Attendance Dump Found in Log Directory. Retrying with dumped data.')
-                        with open(dump_file, 'r') as f:
-                            file_contents = f.read()
-                            if file_contents:
-                                device_attendance_logs = list(map(lambda x: _apply_function_to_key(x, 'timestamp', datetime.datetime.fromtimestamp), json.loads(file_contents)))
+                        os.remove(dump_file)
+                    info_logger.info("Successfully processed Device: "+ device['device_id'])
+                except:
+                    error_logger.exception('exception when calling pull_process_and_push_data function for device'+json.dumps(device, default=str))
+            if hasattr(config,'shift_type_device_mapping'):
+                update_shift_last_sync_timestamp(config.shift_type_device_mapping)
+            status.set('mission_accomplished_timestamp', str(datetime.datetime.now()))
+            info_logger.info("Mission Accomplished!")
+    except:
+        error_logger.exception('exception has occurred in the main function...')
 
-                    try:
-                        pull_process_and_push_data(device, status, device_attendance_logs)
-                        status[f'{device["device_id"]}_push_timestamp'] = str(datetime.datetime.now())
-                        if os.path.exists(dump_file):
-                            os.remove(dump_file)
-                        info_logger.info("Successfully processed Device: " + device['device_id'])
-                    except Exception as e:
-                        error_logger.exception('Exception when calling pull_process_and_push_data function for device' + json.dumps(device, default=str))
-                
-                if hasattr(config, 'shift_type_device_mapping'):
-                    update_shift_last_sync_timestamp(config.shift_type_device_mapping, status)
-                
-                status['mission_accomplished_timestamp'] = str(datetime.datetime.now())
-                info_logger.info("Mission Accomplished!")
-        except Exception as e:
-            error_logger.exception('Exception has occurred in the main function...')
+def pull_process_and_push_data(device, device_attendance_logs=None):
+    """ Takes a single device config as param and pulls data from that device.
 
-def pull_process_and_push_data(device, status, device_attendance_logs=None):
-    """ Takes a single device config and status object as params and pulls data from that device. """
+    params:
+    device: a single device config object from the local_config file
+    device_attendance_logs: fetching from device is skipped if this param is passed. used to restart failed fetches from previous runs.
+    """
     attendance_success_log_file = '_'.join(["attendance_success_log", device['device_id']])
     attendance_failed_log_file = '_'.join(["attendance_failed_log", device['device_id']])
-    attendance_success_logger = setup_logger(attendance_success_log_file, os.path.join(config.LOGS_DIRECTORY, attendance_success_log_file) + '.log')
-    attendance_failed_logger = setup_logger(attendance_failed_log_file, os.path.join(config.LOGS_DIRECTORY, attendance_failed_log_file) + '.log')
-    
+    attendance_success_logger = setup_logger(attendance_success_log_file, '/'.join([config.LOGS_DIRECTORY, attendance_success_log_file])+'.log')
+    attendance_failed_logger = setup_logger(attendance_failed_log_file, '/'.join([config.LOGS_DIRECTORY, attendance_failed_log_file])+'.log')
     if not device_attendance_logs:
-        device_attendance_logs = get_all_attendance_from_device(device['ip'], status, device_id=device['device_id'], 
-                                                             clear_from_device_on_fetch=device['clear_from_device_on_fetch'])
+        device_attendance_logs = get_all_attendance_from_device(device['ip'], device_id=device['device_id'], clear_from_device_on_fetch=device['clear_from_device_on_fetch'])
         if not device_attendance_logs:
             return
-        
+
+    # Parse IMPORT_START_DATE from config
+    import_start_date = getattr(config, 'IMPORT_START_DATE', None)
+    if import_start_date:
+        # Assuming format is 'YYYYMMDD'
+        import_start_date_dt = datetime.datetime.strptime(import_start_date, '%Y%m%d')
+        # Filter logs
+        device_attendance_logs = [
+            log for log in device_attendance_logs
+            if log['timestamp'] >= import_start_date_dt
+        ]
 
     # Collect records for bulk processing
     records_to_insert = []
@@ -116,32 +151,40 @@ def pull_process_and_push_data(device, status, device_attendance_logs=None):
         if not any(error in erpnext_message for error in allowlisted_errors):
             raise Exception('Bulk insert to ERPNext failed.')
 
-def get_all_attendance_from_device(ip, status, port=4370, timeout=30, device_id=None, clear_from_device_on_fetch=False):
-    """Fetch attendance data from ESSL device."""
-    try:
-        # Replace this with ESSL-specific API calls
-        # Example: Use requests to call ESSL device API
-        response = requests.get(f"http://{ip}/api/attendance", timeout=timeout)
-        response.raise_for_status()
-        attendances = response.json()
 
-        if device_id:
-            status[f'{device_id}_push_timestamp'] = None
-            status[f'{device_id}_pull_timestamp'] = str(datetime.datetime.now())
-            
+def get_all_attendance_from_device(ip, port=4370, timeout=30, device_id=None, clear_from_device_on_fetch=False):
+    #  Sample Attendance Logs [{'punch': 255, 'user_id': '22', 'uid': 12349, 'status': 1, 'timestamp': datetime.datetime(2019, 2, 26, 20, 31, 29)},{'punch': 255, 'user_id': '7', 'uid': 7, 'status': 1, 'timestamp': datetime.datetime(2019, 2, 26, 20, 31, 36)}]
+    zk = ZK(ip, port=port, timeout=timeout)
+    conn = None
+    attendances = []
+    try:
+        conn = zk.connect()
+        x = conn.disable_device()
+        # device is disabled when fetching data
+        info_logger.info("\t".join((ip, "Device Disable Attempted. Result:", str(x))))
+        attendances = conn.get_attendance()
+        info_logger.info("\t".join((ip, "Attendances Fetched:", str(len(attendances)))))
+        status.set(f'{device_id}_push_timestamp', None)
+        status.set(f'{device_id}_pull_timestamp', str(datetime.datetime.now()))
         if len(attendances):
+            # keeping a backup before clearing data incase the programs fails.
+            # if everything goes well then this file is removed automatically at the end.
             dump_file_name = get_dump_file_name_and_directory(device_id, ip)
             with open(dump_file_name, 'w+') as f:
-                f.write(json.dumps(attendances, default=datetime.datetime.timestamp))
+                f.write(json.dumps(list(map(lambda x: x.__dict__, attendances)), default=datetime.datetime.timestamp))
             if clear_from_device_on_fetch:
-                # Clear attendance data from device if required
-                requests.post(f"http://{ip}/api/clear_attendance")
-        
-        return attendances
-    except Exception as e:
-        error_logger.exception(f"Exception when fetching from ESSL device {ip}: {str(e)}")
+                x = conn.clear_attendance()
+                info_logger.info("\t".join((ip, "Attendance Clear Attempted. Result:", str(x))))
+        x = conn.enable_device()
+        info_logger.info("\t".join((ip, "Device Enable Attempted. Result:", str(x))))
+    except:
+        error_logger.exception(str(ip)+' exception when fetching from device...')
         raise Exception('Device fetch failed.')
-    
+    finally:
+        if conn:
+            conn.disconnect()
+    return list(map(lambda x: x.__dict__, attendances))
+
 
 def send_to_erpnext_bulk(records):
     """
@@ -155,17 +198,38 @@ def send_to_erpnext_bulk(records):
 
     try:
         response = requests.post(url, headers=headers, json=records)
-        if response.status_code == 200:
-            return 200, response.json().get("message", "Bulk data processed successfully")
+        response_data = response.json()
+        
+        if response.status_code == 200 and response_data.get("success"):
+            info_logger.info(f"Bulk insert result: {response_data.get('message')}")
+            # Only log failed records if they exist
+            if response_data.get("details", {}).get("failed"):
+                for failure in response_data["details"]["failed"]:
+                    error_logger.error(f"Record failed: {json.dumps(failure, default=str)}")
+            return 200, response_data.get("message")
         else:
-            error_str = _safe_get_error_str(response)
+            error_str = response_data.get("message") or _safe_get_error_str(response)
+            error_logger.error(f"Bulk insert failed: {error_str}")
+            # Log detailed failure information if available
+            if response_data.get("details", {}).get("failed"):
+                for failure in response_data["details"]["failed"]:
+                    error_logger.error(f"Record failed: {json.dumps(failure, default=str)}")
             return response.status_code, error_str
+            
     except Exception as e:
-        error_logger.exception(f"API call to ERPNext failed: {str(e)}")
-        return 500, str(e)
+        error_msg = f"API call to ERPNext failed: {str(e)}"
+        error_logger.exception(error_msg)
+        return 500, error_msg
+    
+def update_shift_last_sync_timestamp(shift_type_device_mapping):
+    """
+    ### algo for updating the sync_current_timestamp
+    - get a list of devices to check
+    - check if all the devices have a non 'None' push_timestamp
+        - check if the earliest of the pull timestamp is greater than sync_current_timestamp for each shift name
+            - then update this min of pull timestamp to the shift
 
-def update_shift_last_sync_timestamp(shift_type_device_mapping, status):
-    """Updated to accept status parameter"""
+    """
     for shift_type_device_map in shift_type_device_mapping:
         all_devices_pushed = True
         pull_timestamp_array = []
@@ -174,20 +238,18 @@ def update_shift_last_sync_timestamp(shift_type_device_mapping, status):
                 all_devices_pushed = False
                 break
             pull_timestamp_array.append(_safe_convert_date(status.get(f'{device_id}_pull_timestamp'), "%Y-%m-%d %H:%M:%S.%f"))
-        
-        if all_devices_pushed and pull_timestamp_array:  # Added check for non-empty array
+        if all_devices_pushed:
             min_pull_timestamp = min(pull_timestamp_array)
-            if isinstance(shift_type_device_map['shift_type_name'], str):
+            if isinstance(shift_type_device_map['shift_type_name'], str): # for backward compatibility of config file
                 shift_type_device_map['shift_type_name'] = [shift_type_device_map['shift_type_name']]
-            
             for shift in shift_type_device_map['shift_type_name']:
                 try:
                     sync_current_timestamp = _safe_convert_date(status.get(f'{shift}_sync_timestamp'), "%Y-%m-%d %H:%M:%S.%f")
                     if (sync_current_timestamp and min_pull_timestamp > sync_current_timestamp) or (min_pull_timestamp and not sync_current_timestamp):
                         response_code = send_shift_sync_to_erpnext(shift, min_pull_timestamp)
                         if response_code == 200:
-                            status[f'{shift}_sync_timestamp'] = str(min_pull_timestamp)
-                except Exception as e:
+                            status.set(f'{shift}_sync_timestamp', str(min_pull_timestamp))
+                except:
                     error_logger.exception('Exception in update_shift_last_sync_timestamp, for shift:'+shift)
 
 def send_shift_sync_to_erpnext(shift_type_name, sync_timestamp):
@@ -211,12 +273,17 @@ def send_shift_sync_to_erpnext(shift_type_name, sync_timestamp):
         error_logger.exception("\t".join(['exception when updating last_sync_of_checkin in Shift Type', str(shift_type_name), str(sync_timestamp.timestamp())]))
 
 def get_last_line_from_file(file):
+    # concerns to address(may be much later):
+        # how will last line lookup work with log rotation when a new file is created?
+            #- will that new file be empty at any time? or will it have a partial line from the previous file?
     line = None
     if os.stat(file).st_size < 5000:
+        # quick hack to handle files with one line
         with open(file, 'r') as f:
             for line in f:
                 pass
     else:
+        # optimized for large log files
         with open(file, 'rb') as f:
             f.seek(-2, os.SEEK_END)
             while f.read(1) != b'\n':
@@ -224,7 +291,9 @@ def get_last_line_from_file(file):
             line = f.readline().decode()
     return line
 
+
 def setup_logger(name, log_file, level=logging.INFO, formatter=None):
+
     if not formatter:
         formatter = logging.Formatter('%(asctime)s\t%(levelname)s\t%(message)s')
 
@@ -254,7 +323,7 @@ def _safe_convert_date(datestring, pattern):
 def _safe_get_error_str(res):
     try:
         error_json = json.loads(res._content)
-        if 'exc' in error_json:
+        if 'exc' in error_json: # this means traceback is available
             error_str = json.loads(error_json['exc'])[0]
         else:
             error_str = json.dumps(error_json)
@@ -262,11 +331,30 @@ def _safe_get_error_str(res):
         error_str = str(res.__dict__)
     return error_str
 
-# Setup logger and status
+def get_last_sync_of_checkin(shift_type_name):
+    url = f"{config.ERPNEXT_URL}/api/resource/Shift Type/{shift_type_name}"
+    headers = {
+        'Authorization': f"token {config.ERPNEXT_API_KEY}:{config.ERPNEXT_API_SECRET}",
+        'Accept': 'application/json'
+    }
+    try:
+        response = requests.get(url, headers=headers)
+        if response.status_code == 200:
+            data = response.json()
+            last_sync = data['data'].get('last_sync_of_checkin')
+            if last_sync:
+                # Parse to datetime
+                return datetime.datetime.fromisoformat(last_sync)
+    except Exception as e:
+        error_logger.error(f"Failed to fetch last_sync_of_checkin: {e}")
+    return None
+
+# setup logger and status
 if not os.path.exists(config.LOGS_DIRECTORY):
     os.makedirs(config.LOGS_DIRECTORY)
 error_logger = setup_logger('error_logger', '/'.join([config.LOGS_DIRECTORY, 'error.log']), logging.ERROR)
 info_logger = setup_logger('info_logger', '/'.join([config.LOGS_DIRECTORY, 'logs.log']))
+status = pickledb.load('/'.join([config.LOGS_DIRECTORY, 'status.json']), True)
 
 def infinite_loop(sleep_time=15):
     print("Service Running...")
@@ -279,3 +367,4 @@ def infinite_loop(sleep_time=15):
 
 if __name__ == "__main__":
     infinite_loop()
+


### PR DESCRIPTION
- Fetch last_sync_of_checkin for each device's shift type from ERPNext.
- Filter out all attendance logs with timestamp <= last_sync_of_checkin to avoid re-uploading old data.
- Ensures only new punches are sent to the server, reducing network and server load.
- Improved timestamp handling and error logging for bulk upload responses.